### PR TITLE
Add quick translate feature

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,18 +2,23 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
   </profile>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,11 +67,11 @@ kotlin.sourceSets.all {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.8.0")
-    implementation("androidx.appcompat:appcompat:1.4.2")
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("com.google.android.material:material:1.6.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.1")
-    implementation("androidx.activity:activity-compose:1.4.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
+    implementation("androidx.activity:activity-compose:1.6.0")
 
     // Accompanist
     implementation("com.google.accompanist:accompanist-systemuicontroller:0.17.0")
@@ -87,7 +87,6 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.1.2")
     implementation("io.ktor:ktor-client-logging-jvm:2.1.2")
     implementation("io.ktor:ktor-client-content-negotiation-jvm:2.1.2")
-//    implementation("io.ktor:ktor-client-serialization:2.1.2")
 
     // Compose
     implementation("androidx.compose.ui:ui:$compose_version")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,16 +12,32 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Lingvaandroid">
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.Lingvaandroid.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".QuickTranslateActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:launchMode="singleInstance"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Lingvaandroid.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.TRANSLATE" />
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/dev/atajan/lingva_android/QuickTranslateActivity.kt
+++ b/app/src/main/java/dev/atajan/lingva_android/QuickTranslateActivity.kt
@@ -1,16 +1,19 @@
 package dev.atajan.lingva_android
 
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Text
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import dagger.hilt.android.AndroidEntryPoint
-import dev.atajan.lingva_android.ui.screens.TranslateScreenViewModel
-import dev.atajan.lingva_android.ui.screens.TranslationScreen
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreen
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel
 import dev.atajan.lingva_android.ui.theme.LingvaAndroidTheme
 import dev.atajan.lingva_android.ui.theme.ThemingOptions
 import dev.atajan.lingva_android.ui.theme.canUseDynamicColor
@@ -18,9 +21,9 @@ import dev.atajan.lingva_android.ui.theme.selectedThemeFlow
 
 @ExperimentalMaterialApi
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class QuickTranslateActivity : ComponentActivity() {
 
-    private val viewModel: TranslateScreenViewModel by viewModels()
+    private val viewModel: QuickTranslateScreenViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,11 +45,27 @@ class MainActivity : ComponentActivity() {
             }
 
             LingvaAndroidTheme(appTheme = appTheme) {
-                TranslationScreen(
-                    viewModel = viewModel,
-                    getCurrentTheme = { appTheme }
+                QuickTranslateScreen(
+                    textToTranslate = getTextToTranslate(),
+                    viewModel = viewModel
                 )
             }
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        finish()
+    }
+
+
+    private fun getTextToTranslate(): String {
+        val textToQuickTranslate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            intent.getCharSequenceExtra(Intent.EXTRA_TEXT)
+        } else {
+            null
+        }
+
+        return (textToQuickTranslate ?: intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)) as String
     }
 }

--- a/app/src/main/java/dev/atajan/lingva_android/ui/components/LanguageSelectionBar.kt
+++ b/app/src/main/java/dev/atajan/lingva_android/ui/components/LanguageSelectionBar.kt
@@ -14,14 +14,13 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.SwapHoriz
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -35,9 +34,10 @@ fun LanguageSelectionBar(
     sourceLanguage: LanguageEntity,
     targetLanguage: LanguageEntity,
     toggleErrorDialogState: (Boolean) -> Unit,
-    onSwapLanguageTap: () -> Unit,
     onNewSourceLanguageSelected: (LanguageEntity) -> Unit,
     onNewTargetLanguageSelected: (LanguageEntity) -> Unit,
+    middleIcon: ImageVector,
+    onMiddleIconTap: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -84,13 +84,13 @@ fun LanguageSelectionBar(
         }
 
         IconButton(
-            onClick = onSwapLanguageTap,
+            onClick = onMiddleIconTap,
             modifier = Modifier
                 .fillMaxHeight()
-                .width(60.dp)
+                .fillMaxWidth(0.25f)
         ) {
             Icon(
-                imageVector = Icons.Rounded.SwapHoriz,
+                imageVector = middleIcon,
                 contentDescription = context.getString(R.string.swap_icon_ax),
                 tint = MaterialTheme.colorScheme.onBackground,
                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/dev/atajan/lingva_android/ui/screens/QuickTranslateScreen.kt
+++ b/app/src/main/java/dev/atajan/lingva_android/ui/screens/QuickTranslateScreen.kt
@@ -1,0 +1,166 @@
+package dev.atajan.lingva_android.ui.screens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Card
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowRightAlt
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import dev.atajan.lingva_android.R
+import dev.atajan.lingva_android.ui.components.ErrorNotificationDialog
+import dev.atajan.lingva_android.ui.components.LanguageSelectionBar
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.CopyTextToClipboard
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.OnTextToTranslateChange
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.SetNewSourceLanguage
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.SetNewTargetLanguage
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.ShowErrorDialog
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.Translate
+import dev.atajan.lingva_android.ui.theme.mediumRoundedCornerShape
+
+@ExperimentalMaterialApi
+@Composable
+fun QuickTranslateScreen(
+    textToTranslate: String,
+    viewModel: QuickTranslateScreenViewModel
+) {
+    val context = LocalContext.current
+    val scrollState = rememberScrollState(0)
+    val quickTranslateScreenState by viewModel.states.collectAsState()
+
+    viewModel.send(OnTextToTranslateChange(textToTranslate))
+    
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        LanguageSelectionBar(
+            modifier = Modifier.padding(all = 16.dp),
+            supportedLanguages = quickTranslateScreenState.supportedLanguages,
+            sourceLanguage = quickTranslateScreenState.sourceLanguage,
+            targetLanguage = quickTranslateScreenState.targetLanguage,
+            toggleErrorDialogState = {
+                viewModel.send(ShowErrorDialog(it))
+            },
+            middleIcon = Icons.Rounded.ArrowRightAlt,
+            onMiddleIconTap = { 
+                // No action necessary for this user flow
+            },
+            onNewSourceLanguageSelected = {
+                viewModel.send(SetNewSourceLanguage(it))
+                viewModel.send(Translate)
+            },
+            onNewTargetLanguageSelected = {
+                viewModel.send(SetNewTargetLanguage(it))
+                viewModel.send(Translate)
+            }
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.40f)
+                .padding(all = 16.dp)
+        ) {
+            OutlinedTextField(
+                value = quickTranslateScreenState.textToTranslate,
+                onValueChange = { },
+                label = {
+                    Text(
+                        text = context.getString(R.string.source_text),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                },
+                modifier = Modifier.fillMaxSize(),
+                textStyle = MaterialTheme.typography.titleMedium,
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = MaterialTheme.colorScheme.primary.copy(alpha = ContentAlpha.high),
+                    unfocusedBorderColor = MaterialTheme.colorScheme.primary.copy(alpha = ContentAlpha.high),
+                    focusedLabelColor = MaterialTheme.colorScheme.primary.copy(alpha = ContentAlpha.high),
+                    unfocusedLabelColor = MaterialTheme.colorScheme.primary.copy(alpha = ContentAlpha.high),
+                    cursorColor = MaterialTheme.colorScheme.primary,
+                    textColor = MaterialTheme.colorScheme.onBackground,
+                ),
+                readOnly = true
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.95f)
+                .padding(all = 16.dp)
+        ) {
+            Card(
+                shape = mediumRoundedCornerShape,
+                border = BorderStroke(
+                    width = 2.dp,
+                    color = MaterialTheme.colorScheme.primary
+                ),
+                elevation = 0.dp,
+                backgroundColor = MaterialTheme.colorScheme.background,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                SelectionContainer {
+                    Text(
+                        quickTranslateScreenState.translatedText,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .verticalScroll(scrollState)
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.Bottom
+            ) {
+                IconButton(
+                    onClick = {
+                        viewModel.send(CopyTextToClipboard)
+                    },
+                    modifier = Modifier
+                        .padding(bottom = 16.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.ContentCopy,
+                        contentDescription = context.getString(R.string.copy_icon_ax),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+    }
+
+    ErrorNotificationDialog(quickTranslateScreenState.errorDialogState) {
+        viewModel.send(ShowErrorDialog(false))
+    }
+}

--- a/app/src/main/java/dev/atajan/lingva_android/ui/screens/QuickTranslateScreenViewModel.kt
+++ b/app/src/main/java/dev/atajan/lingva_android/ui/screens/QuickTranslateScreenViewModel.kt
@@ -1,0 +1,197 @@
+package dev.atajan.lingva_android.ui.screens
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.lifecycle.viewModelScope
+import com.github.michaelbull.result.fold
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.atajan.lingva_android.MainApplication
+import dev.atajan.lingva_android.api.entities.LanguageEntity
+import dev.atajan.lingva_android.datastore.DEFAULT_TARGET_LANGUAGE
+import dev.atajan.lingva_android.datastore.dataStore
+import dev.atajan.lingva_android.mvi.MVIViewModel
+import dev.atajan.lingva_android.mvi.MiddleWare
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.CopyTextToClipboard
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.OnTextToTranslateChange
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.SetDefaultTargetLanguage
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.SetNewSourceLanguage
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.SetNewTargetLanguage
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.ShowErrorDialog
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.SupportedLanguagesReceived
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.Translate
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.TranslationFailure
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.Intention.TranslationSuccess
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.SideEffect
+import dev.atajan.lingva_android.ui.screens.QuickTranslateScreenViewModel.State
+import dev.atajan.lingva_android.usecases.GetSupportedLanguagesUseCase
+import dev.atajan.lingva_android.usecases.GetTranslationUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class QuickTranslateScreenViewModel @Inject constructor(
+    private val application: MainApplication,
+    private val getSupportedLanguages: GetSupportedLanguagesUseCase,
+    private val translate: GetTranslationUseCase,
+    applicationScope: CoroutineScope,
+) : MVIViewModel<State, Intention, SideEffect>(
+    scope = applicationScope,
+    initialState = State()
+) {
+    private val dataStore = application.applicationContext.dataStore
+
+    init {
+        viewModelScope.launch {
+            getSupportedLanguages().fold(
+                success = {
+                    send(SupportedLanguagesReceived(it.languages))
+                },
+                failure = {
+                    send(ShowErrorDialog(true))
+                }
+            )
+
+            dataStore.data.mapNotNull {
+                it[DEFAULT_TARGET_LANGUAGE]
+            }
+                .distinctUntilChanged()
+                .onEach {
+                    send(SetDefaultTargetLanguage(it))
+                }
+                .launchIn(this)
+
+            send(Translate)
+        }
+    }
+
+    override fun reduce(
+        currentState: State,
+        intention: Intention,
+        middleWares: List<MiddleWare<State, Intention>>
+    ): State {
+        return when (intention) {
+            is SetDefaultTargetLanguage -> {
+                if (currentState.defaultTargetLanguage != intention.languageName) {
+                    getDefaultLanguageIfProvided(
+                        supportedLanguages = currentState.supportedLanguages,
+                        lookUpLanguage = intention.languageName
+                    ).let { language ->
+                        currentState.copy(
+                            targetLanguage = language ?: currentState.targetLanguage,
+                            defaultTargetLanguage = language?.name ?: currentState.defaultTargetLanguage
+                        )
+                    }
+                } else {
+                    currentState
+                }
+            }
+            is SetNewSourceLanguage -> currentState.copy(sourceLanguage = intention.language)
+            is SetNewTargetLanguage -> currentState.copy(targetLanguage = intention.language)
+            is ShowErrorDialog -> currentState.copy(errorDialogState = intention.show)
+            is SupportedLanguagesReceived -> currentState.copy(supportedLanguages = intention.languages)
+            is TranslationSuccess -> currentState.copy(translatedText = intention.result)
+            Translate -> {
+                requestTranslation(
+                    sourceLanguageCode = currentState.sourceLanguage.code,
+                    targetLanguageCode = currentState.targetLanguage.code,
+                    textToTranslate = currentState.textToTranslate,
+                    supportedLanguages = currentState.supportedLanguages
+                )
+                currentState
+            }
+            TranslationFailure -> currentState
+            CopyTextToClipboard -> {
+                copyTextToClipboard(currentState.translatedText)
+                currentState
+            }
+
+            is OnTextToTranslateChange -> {
+                currentState.copy(textToTranslate = intention.newValue)
+            }
+        }
+    }
+
+    private fun requestTranslation(
+        sourceLanguageCode: String,
+        targetLanguageCode: String,
+        textToTranslate: String,
+        supportedLanguages: List<LanguageEntity>
+    ) {
+        viewModelScope.launch {
+            translate(
+                source = sourceLanguageCode,
+                target = targetLanguageCode,
+                query = textToTranslate
+            ).fold(
+                success = {
+                    send(TranslationSuccess(it.translation))
+
+                    if (sourceLanguageCode == "auto") {
+                        it.info?.detectedSource?.let { detectedSourceLanguageCode ->
+                            supportedLanguages
+                                .find { languageEntity ->
+                                    languageEntity.code == detectedSourceLanguageCode
+                                }
+                                ?.let { detectedSourceLanguage ->
+                                    send(
+                                        SetNewSourceLanguage(
+                                            detectedSourceLanguage
+                                        )
+                                    )
+                                }
+                        }
+                    }
+                },
+                failure = {
+                    send(TranslationFailure)
+                }
+            )
+        }
+    }
+
+    private fun copyTextToClipboard(translatedText: String) {
+        val clipboardManager = application.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clipData = ClipData.newPlainText("Translation", translatedText)
+
+        clipboardManager.setPrimaryClip(clipData)
+    }
+
+    private fun getDefaultLanguageIfProvided(
+        supportedLanguages: List<LanguageEntity>,
+        lookUpLanguage: String
+    ): LanguageEntity? {
+        return supportedLanguages.find { it.name == lookUpLanguage }
+    }
+
+
+    data class State(
+        val supportedLanguages: List<LanguageEntity> = emptyList(),
+        val translatedText: String = "",
+        val sourceLanguage: LanguageEntity = LanguageEntity("auto", "Detect"),
+        val targetLanguage: LanguageEntity = LanguageEntity("es", "Spanish"),
+        val textToTranslate: String = "",
+        val errorDialogState: Boolean = false,
+        val defaultTargetLanguage: String = ""
+    )
+
+    sealed interface Intention {
+        data class OnTextToTranslateChange(val newValue: String) : Intention
+        data class SetDefaultTargetLanguage(val languageName: String) : Intention
+        data class SetNewSourceLanguage(val language: LanguageEntity) : Intention
+        data class SetNewTargetLanguage(val language: LanguageEntity) : Intention
+        data class ShowErrorDialog(val show: Boolean) : Intention
+        data class SupportedLanguagesReceived(val languages: List<LanguageEntity>) : Intention
+        data class TranslationSuccess(val result: String) : Intention
+        object CopyTextToClipboard : Intention
+        object Translate : Intention
+        object TranslationFailure : Intention
+    }
+    sealed interface SideEffect
+}

--- a/app/src/main/java/dev/atajan/lingva_android/ui/screens/TranslateScreen.kt
+++ b/app/src/main/java/dev/atajan/lingva_android/ui/screens/TranslateScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
@@ -25,6 +24,7 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ContentCopy
 import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.SwapHoriz
 import androidx.compose.material.icons.rounded.Translate
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Icon
@@ -37,7 +37,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
@@ -94,13 +93,15 @@ fun TranslationScreen(
                     }
                 }
             },
-            modifier = Modifier.padding(all = 16.dp)
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(top = 16.dp)
         )
 
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(0.40f)
+                .fillMaxHeight(0.4f)
                 .padding(all = 16.dp)
         ) {
             OutlinedTextField(
@@ -175,7 +176,7 @@ fun TranslationScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .fillMaxHeight(0.7f)
+                    .fillMaxHeight(0.75f)
                     .padding(all = 16.dp)
             ) {
                 Card(
@@ -230,7 +231,8 @@ fun TranslationScreen(
             toggleErrorDialogState = {
                 viewModel.send(ShowErrorDialog(it))
             },
-            onSwapLanguageTap = { viewModel.send(TrySwapLanguages) },
+            middleIcon = Icons.Rounded.SwapHoriz,
+            onMiddleIconTap = { viewModel.send(TrySwapLanguages) },
             onNewSourceLanguageSelected = { viewModel.send(SetNewSourceLanguage(it)) },
             onNewTargetLanguageSelected = { viewModel.send(SetNewTargetLanguage(it)) }
         )

--- a/app/src/main/java/dev/atajan/lingva_android/ui/screens/TranslateScreenViewModel.kt
+++ b/app/src/main/java/dev/atajan/lingva_android/ui/screens/TranslateScreenViewModel.kt
@@ -56,7 +56,6 @@ class TranslateScreenViewModel @Inject constructor(
     scope = applicationScope,
     initialState = State()
 ) {
-
     private val dataStore = application.applicationContext.dataStore
 
     private val stateLogger: MiddleWare<State, Intention> by lazy {
@@ -114,9 +113,7 @@ class TranslateScreenViewModel @Inject constructor(
 
         return when (intention) {
             is ShowErrorDialog -> currentState.copy(errorDialogState = intention.show)
-            is SupportedLanguagesReceived -> {
-                currentState.copy(supportedLanguages = intention.languages)
-            }
+            is SupportedLanguagesReceived -> currentState.copy(supportedLanguages = intention.languages)
             is DefaultSourceLanguageSelected -> {
                 setDefaultSourceLanguage(intention.language)
                 currentState
@@ -278,23 +275,23 @@ class TranslateScreenViewModel @Inject constructor(
     )
 
     sealed interface Intention {
-        class OnTextToTranslateChange(val newValue: String) : Intention
-        class DefaultSourceLanguageSelected(val language: LanguageEntity) : Intention
-        class DefaultTargetLanguageSelected(val language: LanguageEntity) : Intention
-        class SetDefaultTargetLanguage(val languageName: String) : Intention
-        class SetDefaultSourceLanguage(val languageName: String) : Intention
-        class SetNewSourceLanguage(val language: LanguageEntity) : Intention
-        class SetNewTargetLanguage(val language: LanguageEntity) : Intention
-        class ShowErrorDialog(val show: Boolean) : Intention
-        class SupportedLanguagesReceived(val languages: List<LanguageEntity>) : Intention
-        class TranslationSuccess(val result: String) : Intention
+        data class OnTextToTranslateChange(val newValue: String) : Intention
+        data class DefaultSourceLanguageSelected(val language: LanguageEntity) : Intention
+        data class DefaultTargetLanguageSelected(val language: LanguageEntity) : Intention
+        data class SetDefaultTargetLanguage(val languageName: String) : Intention
+        data class SetDefaultSourceLanguage(val languageName: String) : Intention
+        data class SetNewSourceLanguage(val language: LanguageEntity) : Intention
+        data class SetNewTargetLanguage(val language: LanguageEntity) : Intention
+        data class ShowErrorDialog(val show: Boolean) : Intention
+        data class SupportedLanguagesReceived(val languages: List<LanguageEntity>) : Intention
+        data class TranslationSuccess(val result: String) : Intention
         object ClearInputField : Intention
         object CopyTextToClipboard : Intention
         object Translate : Intention
         object TranslationFailure : Intention
         object TrySwapLanguages : Intention
-        class ToggleAppTheme(val newTheme: ThemingOptions) : Intention
+        data class ToggleAppTheme(val newTheme: ThemingOptions) : Intention
     }
 
-    sealed class SideEffect
+    sealed interface SideEffect
 }

--- a/app/src/main/java/dev/atajan/lingva_android/ui/theme/Helpers.kt
+++ b/app/src/main/java/dev/atajan/lingva_android/ui/theme/Helpers.kt
@@ -1,0 +1,14 @@
+package dev.atajan.lingva_android.ui.theme
+
+import android.content.Context
+import dev.atajan.lingva_android.datastore.APP_THEME
+import dev.atajan.lingva_android.datastore.dataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+fun selectedThemeFlow(applicationContext: Context): Flow<String?> {
+    return applicationContext.dataStore.data
+        .map { preferences ->
+            preferences[APP_THEME]
+        }
+}


### PR DESCRIPTION
This PR introduces the feature requested in #10 - not a pop-up translate due to some issues with Fragment/Jetpack compose interop but should be a good starting point to iterate upon.

Demo: https://drive.google.com/file/d/1_xyAXacDnTioEaixSsEMBZcKqGQxH2yc/view?usp=sharing